### PR TITLE
[fix/50_animated_splash_screen] [Issue-50] Added animation splash at startup.

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,6 +10,7 @@ import * as Sentry from "sentry-expo";
 import { Provider } from "react-redux";
 import AppNavigator from "./app/navigation/Navigator/AppNavigator";
 import store from "./app/redux/store";
+import SplashScreen from "./app/screens/Splash";
 import { LocalizationContext } from "./app/utils";
 
 const supportedLanguages = ["en", "fr", "de", "sv"];
@@ -21,7 +22,7 @@ const secret =
 Sentry.init({
   dsn: secret.dsn,
   enableInExpoDevelopment: false,
-  debug: true,
+  debug: true
 });
 
 /* TODO: set Constants.manifest.revisionId with expo */
@@ -45,6 +46,7 @@ const App = () => {
   }
 
   const [ready, setReady] = useState(false);
+  const [splashAnimation, setSplashAnimation] = useState(false); // to track splashScreen animation
   const [language, setLanguage] = useState(lang);
   const [locale, setLocale] = useState(localeExpo);
 
@@ -69,16 +71,23 @@ const App = () => {
         "Inter-SemiBold": require("./assets/fonts/Inter-SemiBold.ttf"),
         "Inter-SemiBoldItalic": require("./assets/fonts/Inter-SemiBoldItalic.ttf"),
         "Inter-Thin-BETA": require("./assets/fonts/Inter-Thin-BETA.ttf"),
-        "Inter-ThinItalic-BETA": require("./assets/fonts/Inter-ThinItalic-BETA.ttf"),
-      }),
+        "Inter-ThinItalic-BETA": require("./assets/fonts/Inter-ThinItalic-BETA.ttf")
+      })
     ])
-      .then(() => setReady(true))
-      .catch((error) => Sentry.captureException(error));
+      .then(() => {
+        setReady(true);
+      })
+      .catch(error => Sentry.captureException(error));
   }, []);
+
+  // callback to get splashScreen animation completion
+  const screenAnimationComplete = animation => {
+    setSplashAnimation(animation);
+  };
 
   return (
     <>
-      {ready ? (
+      {ready && splashAnimation ? (
         <Provider store={store}>
           <FormattedProvider locale={language || "en"}>
             <LocalizationContext.Provider
@@ -86,7 +95,7 @@ const App = () => {
                 locale: locale || "en-US",
                 setLocale: setLocale,
                 language: language || "en",
-                setLanguage: setLanguage,
+                setLanguage: setLanguage
               }}
             >
               <AppNavigator />
@@ -94,7 +103,7 @@ const App = () => {
           </FormattedProvider>
         </Provider>
       ) : (
-        <View />
+        <SplashScreen screenAnimationComplete={screenAnimationComplete} />
       )}
     </>
   );

--- a/app.example.json
+++ b/app.example.json
@@ -7,11 +7,6 @@
     "platforms": ["ios", "android"],
     "version": "0.3.0",
     "orientation": "portrait",
-    "splash": {
-      "image": "./assets/images/splash.png",
-      "resizeMode": "contain",
-      "backgroundColor": "#ffffff"
-    },
     "updates": {
       "fallbackToCacheTimeout": 0
     },

--- a/app/screens/Splash/SplashScreen.styles.ts
+++ b/app/screens/Splash/SplashScreen.styles.ts
@@ -1,0 +1,9 @@
+import { StyleSheet } from "react-native";
+
+export default StyleSheet.create({
+  view: { flex: 1, alignItems: "center", justifyContent: "center" },
+  animationImage: {
+    height: 450,
+    width: 450
+  }
+});

--- a/app/screens/Splash/SplashScreen.tsx
+++ b/app/screens/Splash/SplashScreen.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect } from "react";
+import { Animated, View } from "react-native";
+import styles from "./SplashScreen.styles";
+
+interface Props {
+  screenAnimationComplete: (boolean) => void;
+}
+
+const SplashScreen = (props: Props) => {
+  const fadeAnim = new Animated.Value(1);
+
+  useEffect(() => {
+    Animated.timing(fadeAnim, {
+      toValue: 0,
+      duration: 3000,
+      useNativeDriver: false
+    }).start(({ finished }) => {
+      props.screenAnimationComplete(finished);
+    });
+  }, [fadeAnim]);
+
+  return (
+    <View style={styles.view}>
+      <Animated.Image
+        resizeMode={"cover"}
+        source={require("../../../assets/images/splash.png")}
+        style={[styles.animationImage, { opacity: fadeAnim }]}
+      />
+    </View>
+  );
+};
+
+export default SplashScreen;

--- a/app/screens/Splash/index.ts
+++ b/app/screens/Splash/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SplashScreen";


### PR DESCRIPTION
Added Splash Screen animation at the application startup. App logo gets fade-in as the app time progresses over startup.
Also, removed splash key from app.json to handle animation.

**TODO**: write test cases.
