### PR TITLE
fix: dark-mode support for IOS datepicker

### DIFF
--- a/app/screens/AddEmission/AddEmissionScreen.tsx
+++ b/app/screens/AddEmission/AddEmissionScreen.tsx
@@ -23,6 +23,7 @@ import {
   t,
   withLocalization,
   LocalizationContextProps,
+  ui
 } from "../../utils";
 import { userPreferences } from "../../ducks";
 
@@ -184,6 +185,8 @@ const AddEmissionScreen = ({
     return null;
   };
 
+  const isDarkModeEnabled = ui.isDarkModeEnabled()
+
   return (
     <KeyboardAwareScrollView style={styles.container}>
       <View style={styles.typeContainer}>
@@ -249,6 +252,7 @@ const AddEmissionScreen = ({
         cancelTextIOS={t("ADD_EMISSION_PICKER_MODAL_CANCEL")}
         locale={locale}
         isVisible={isDatePickerVisible}
+        isDarkModeEnabled={isDarkModeEnabled}
         mode="date"
         onConfirm={handleConfirm}
         onCancel={hideDatePicker}

--- a/app/utils/ui/ui.ts
+++ b/app/utils/ui/ui.ts
@@ -1,3 +1,4 @@
+import { Appearance } from "react-native";
 import {
   TransportEnum,
   FoodEnum,
@@ -96,4 +97,8 @@ const getIconFromModelType = (emissionModelType) => {
   }
 };
 
-export default { getTranslationModelType, getIconFromModelType };
+const isDarkModeEnabled = () => {
+  return Appearance.getColorScheme() === "dark"
+}
+
+export default { getTranslationModelType, getIconFromModelType, isDarkModeEnabled };


### PR DESCRIPTION
fix for the second part of issue #151 

<img width="359" alt="Screenshot 2020-08-11 at 08 45 45" src="https://user-images.githubusercontent.com/26928860/89871509-6e080300-dbaf-11ea-9af2-499e8b93a8bb.png">
