### PR TITLE
wrap AddEmissions navigation in a function to fix currying error

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -4,4 +4,5 @@ module.exports = {
   singleQuote: false,
   printWidth: 80,
   tabWidth: 2,
+  endOfLine: "auto"
 };

--- a/app/components/NoEmission/NoEmission.tsx
+++ b/app/components/NoEmission/NoEmission.tsx
@@ -25,7 +25,7 @@ export default function NoEmission() {
         <Button.Primary
           fullWidth
           style={styles.button}
-          onPress={navigator.openAddEmission}
+          onPress={() => navigator.openAddEmission()}
           textType={"Primary"}
         >
           <Text.Primary bold white>

--- a/app/screens/Emissions/components/AddEmissionAndMitigateButtons/AddEmissionAndMitigateButtons.tsx
+++ b/app/screens/Emissions/components/AddEmissionAndMitigateButtons/AddEmissionAndMitigateButtons.tsx
@@ -24,7 +24,7 @@ const AddEmissionAndMitigateButtons = () => {
       </Button.Secondary>
       <Button.Primary
         style={styles.buttonRight}
-        onPress={navigator.openAddEmission}
+        onPress={() => navigator.openAddEmission()}
         textType={"Secondary"}
       >
         <Text.Secondary numberOfLines={1} center white bold>

--- a/app/screens/Emissions/components/EmissionsList/__tests__/__snapshots__/EmissionsList.test.tsx.snap
+++ b/app/screens/Emissions/components/EmissionsList/__tests__/__snapshots__/EmissionsList.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`EmissionsList renders correctly 1`] = `
             "value": 100,
           },
         ],
-        "date": "2020-03-01T00:00:00+00:00",
+        "date": "2020-03-01T00:00:00-06:00",
       },
       Object {
         "co2value": 60,
@@ -51,7 +51,7 @@ exports[`EmissionsList renders correctly 1`] = `
             "value": 30,
           },
         ],
-        "date": "2020-01-01T00:00:00+00:00",
+        "date": "2020-01-01T00:00:00-06:00",
       },
     ]
   }
@@ -87,7 +87,7 @@ exports[`EmissionsList renders correctly 1`] = `
     >
       <SectionHeader
         co2value={20.0803}
-        date="2020-03-01T00:00:00+00:00"
+        date="2020-03-01T00:00:00-06:00"
         monthlyCarbonBudget={24}
       />
     </View>
@@ -127,7 +127,7 @@ exports[`EmissionsList renders correctly 1`] = `
     >
       <SectionHeader
         co2value={60}
-        date="2020-01-01T00:00:00+00:00"
+        date="2020-01-01T00:00:00-06:00"
         monthlyCarbonBudget={24}
       />
     </View>

--- a/app/screens/Emissions/components/EmissionsList/__tests__/__snapshots__/EmissionsList.test.tsx.snap
+++ b/app/screens/Emissions/components/EmissionsList/__tests__/__snapshots__/EmissionsList.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`EmissionsList renders correctly 1`] = `
             "value": 100,
           },
         ],
-        "date": "2020-03-01T00:00:00-06:00",
+        "date": "2020-03-01T00:00:00+00:00",
       },
       Object {
         "co2value": 60,
@@ -51,7 +51,7 @@ exports[`EmissionsList renders correctly 1`] = `
             "value": 30,
           },
         ],
-        "date": "2020-01-01T00:00:00-06:00",
+        "date": "2020-01-01T00:00:00+00:00",
       },
     ]
   }
@@ -87,7 +87,7 @@ exports[`EmissionsList renders correctly 1`] = `
     >
       <SectionHeader
         co2value={20.0803}
-        date="2020-03-01T00:00:00-06:00"
+        date="2020-03-01T00:00:00+00:00"
         monthlyCarbonBudget={24}
       />
     </View>
@@ -127,7 +127,7 @@ exports[`EmissionsList renders correctly 1`] = `
     >
       <SectionHeader
         co2value={60}
-        date="2020-01-01T00:00:00-06:00"
+        date="2020-01-01T00:00:00+00:00"
         monthlyCarbonBudget={24}
       />
     </View>


### PR DESCRIPTION
Addresses #135 

I figured out that the currying that is done when calling the navigation in combination with React automatically passing in the button pressed event into onPressed was causing params to be that unserializable event rather than an empty object. Wrapping the call in a function prevents that behavior and allows for a params object to be passed in as an argument if we wanted to actually pass some in in the future.

This might be a problem in other areas where you're directly passing the navigation function into an onPressed prop, but didn't want to blow up the scope of the issue.

Also, I had to make some changes to the project config to be able to commit from Windows. 
1. I had to add `endOfLine: "auto"` to the `.prettierrc.js` file or the different style of line endings caused prettier errors in every file.
1. I didn't commit this change, but I had to temporarily change the `test` script in `project.json`
```json
    "test": "SET TZ=GMT && jest",
```
I didn't want to break the script for other machines which is why I didn't include it, but this could be a bother for other people developing on Windows. Do you mind if I submit an issue to look into making this completely cross-compatible?

UPDATE: while the above second step does let you run `yarn test` on windows, it doesn't successfully set the timezone causing my snapshots to get incorrectly updated. Searching around, it doesn't seem like there's a good way to set the TZ env var in windows prior to running jest 😢 For now, it suffices to update the snapshots and then revert any timezone changes.