### PR TITLE
Add max width for chart container for big screens

### DIFF
--- a/app/screens/Budget/components/ProgressChart/ProgressChart.styles.ts
+++ b/app/screens/Budget/components/ProgressChart/ProgressChart.styles.ts
@@ -17,8 +17,6 @@ export default StyleSheet.create({
     flex: 1,
     maxWidth: 500,
     alignSelf: "center",
-    justifyContent: "center",
-    alignItems: "center",
   },
   periodContainer: {
     flex: 1,

--- a/app/screens/Budget/components/ProgressChart/ProgressChart.styles.ts
+++ b/app/screens/Budget/components/ProgressChart/ProgressChart.styles.ts
@@ -15,6 +15,10 @@ export default StyleSheet.create({
     paddingTop: 10,
     marginHorizontal: platform.isIOS ? 0 : 2,
     flex: 1,
+    maxWidth: 500,
+    alignSelf: "center",
+    justifyContent: "center",
+    alignItems: "center",
   },
   periodContainer: {
     flex: 1,

--- a/app/screens/Budget/components/ProgressChart/__tests__/__snapshots__/ProgressChart.test.tsx.snap
+++ b/app/screens/Budget/components/ProgressChart/__tests__/__snapshots__/ProgressChart.test.tsx.snap
@@ -4,14 +4,12 @@ exports[`ProgressChart renders correctly 1`] = `
 <View
   style={
     Object {
-      "alignItems": "center",
       "alignSelf": "center",
       "backgroundColor": "#FFFFFF",
       "borderColor": "#DCF0E5",
       "borderRadius": 14,
       "borderWidth": 2,
       "flex": 1,
-      "justifyContent": "center",
       "marginHorizontal": 0,
       "marginVertical": 24,
       "maxWidth": 500,

--- a/app/screens/Budget/components/ProgressChart/__tests__/__snapshots__/ProgressChart.test.tsx.snap
+++ b/app/screens/Budget/components/ProgressChart/__tests__/__snapshots__/ProgressChart.test.tsx.snap
@@ -4,13 +4,17 @@ exports[`ProgressChart renders correctly 1`] = `
 <View
   style={
     Object {
+      "alignItems": "center",
+      "alignSelf": "center",
       "backgroundColor": "#FFFFFF",
       "borderColor": "#DCF0E5",
       "borderRadius": 14,
       "borderWidth": 2,
       "flex": 1,
+      "justifyContent": "center",
       "marginHorizontal": 0,
       "marginVertical": 24,
+      "maxWidth": 500,
       "paddingBottom": 14,
       "paddingHorizontal": 14,
       "paddingTop": 10,

--- a/app/screens/Budget/components/ProgressChart/components/Chart/Chart.styles.ts
+++ b/app/screens/Budget/components/ProgressChart/components/Chart/Chart.styles.ts
@@ -3,5 +3,6 @@ import { StyleSheet } from "react-native";
 export default StyleSheet.create({
   container: {
     flex: 1,
+    alignSelf: "center",
   },
 });

--- a/app/screens/Budget/components/ProgressChart/components/Chart/__tests__/__snapshots__/Chart.test.tsx.snap
+++ b/app/screens/Budget/components/ProgressChart/components/Chart/__tests__/__snapshots__/Chart.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Chart renders correctly 1`] = `
 <View
   style={
     Object {
+      "alignSelf": "center",
       "flex": 1,
     }
   }


### PR DESCRIPTION
related to #111 
![Simulator Screen Shot - iPad Pro (11-inch) (2nd generation) - 2020-10-11 at 00 29 50](https://user-images.githubusercontent.com/10198892/95664988-2ecb4380-0b59-11eb-9db2-16c6c99b7a37.png)
