### PR TITLE
update emissionslist to use utc and fixed tests

### DIFF
--- a/app/screens/Emissions/components/EmissionsList/__tests__/__snapshots__/EmissionsList.test.tsx.snap
+++ b/app/screens/Emissions/components/EmissionsList/__tests__/__snapshots__/EmissionsList.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`EmissionsList renders correctly 1`] = `
             "value": 100,
           },
         ],
-        "date": "2020-03-01T00:00:00+00:00",
+        "date": "2020-03-01T00:00:00Z",
       },
       Object {
         "co2value": 60,
@@ -51,7 +51,7 @@ exports[`EmissionsList renders correctly 1`] = `
             "value": 30,
           },
         ],
-        "date": "2020-01-01T00:00:00+00:00",
+        "date": "2020-01-01T00:00:00Z",
       },
     ]
   }
@@ -87,7 +87,7 @@ exports[`EmissionsList renders correctly 1`] = `
     >
       <SectionHeader
         co2value={20.0803}
-        date="2020-03-01T00:00:00+00:00"
+        date="2020-03-01T00:00:00Z"
         monthlyCarbonBudget={24}
       />
     </View>
@@ -127,7 +127,7 @@ exports[`EmissionsList renders correctly 1`] = `
     >
       <SectionHeader
         co2value={60}
-        date="2020-01-01T00:00:00+00:00"
+        date="2020-01-01T00:00:00Z"
         monthlyCarbonBudget={24}
       />
     </View>

--- a/app/screens/Emissions/ducks/EmissionsScreen.selectors.ts
+++ b/app/screens/Emissions/ducks/EmissionsScreen.selectors.ts
@@ -26,7 +26,7 @@ const getEmissionListItem = (item: Emission) => {
   return emissionItem;
 };
 
-const getStartOfMonth = (time) => moment(time).startOf("month").format();
+const getStartOfMonth = (time) => moment.utc(time).startOf("month").format();
 
 const groupByMonth = groupBy((item: EmissionListItem) =>
   getStartOfMonth(item.creationDate)

--- a/app/screens/Emissions/ducks/__tests__/EmissionsScreen.selectors.test.ts
+++ b/app/screens/Emissions/ducks/__tests__/EmissionsScreen.selectors.test.ts
@@ -9,11 +9,11 @@ import { calculation } from "../../../../utils";
 
 let state;
 
-const christmas = moment("2020-12-24T03:24:00");
-const monthsAgo = moment().subtract(2, "month");
+const christmas = moment.utc("2020-12-24T03:24:00");
+const monthsAgo = moment().utc().subtract(2, "month");
 
 /* TODO: remove this function copied from selectors file */
-const getStartOfMonth = (time) => moment(time).startOf("month").format();
+const getStartOfMonth = (time) => moment.utc(time).startOf("month").format();
 
 const emissionNotMitigatedOld: EmissionType = {
   id: "3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "web": "expo start --web",
     "eject": "expo eject",
     "test:watch": "jest --watchAll",
-    "test": "TZ=GMT jest",
+    "test": "jest",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx ./app",
     "lint:fix": "eslint --ext .js,.jsx,.ts,.tsx ./app --fix",
     "typescript": "tsc --noEmit",


### PR DESCRIPTION
Addresses #205 

I couldn't find a good way to set jest to UTC in a way that worked with windows, but I dug deeper and realized it was only relevant for the EmissionsList tests. It took me a while to track down where the offending code was, because the test seemed to be always using utc when passing dates around. Turns out that groupBy function news up a new moment object with the time passed in which was causing it to tack on the timezone even though it just wants a start of the month date. 

This change could _possibly_ affect how the emissions are displayed to users if they created it right on the start or end of a month and their timezone pushes it across the edge since it would be using the utc date instead of their local date. Let me know if you have any suggestions here. There might be a way to chop off the timezone information after the start of month is evaluated (calling utc after the fact adjusted the time value of the date)