### PR TITLE
move change button to next line

### DIFF
--- a/app/screens/AddEmission/AddEmissionScreen.styles.ts
+++ b/app/screens/AddEmission/AddEmissionScreen.styles.ts
@@ -25,9 +25,6 @@ export default StyleSheet.create({
     paddingLeft: ConstantsLayout.PADDING_HORIZONTAL,
     flexDirection: "row",
   },
-  changeBtn: {
-    paddingLeft: 4,
-  },
   separator: {
     ...Layout.separator,
   },

--- a/app/screens/AddEmission/AddEmissionScreen.tsx
+++ b/app/screens/AddEmission/AddEmissionScreen.tsx
@@ -265,15 +265,12 @@ const AddEmissionScreen = ({
           <Text.Primary lightGray bold>
             {creationDate.locale(language).format("dddd Do MMMM YYYY")}
           </Text.Primary>
-          <Text.Primary lightGray bold>
-            {" - "}
-          </Text.Primary>
-          <TouchableOpacity style={styles.changeBtn} onPress={showDatePicker}>
-            <Text.Primary bold green>
-              {t("ADD_EMISSION_CHANGE")}
-            </Text.Primary>
-          </TouchableOpacity>
         </View>
+        <TouchableOpacity onPress={showDatePicker}>
+          <Text.Primary bold green>
+            {t("ADD_EMISSION_CHANGE")}
+          </Text.Primary>
+        </TouchableOpacity>
       </View>
 
       <AddEmissionButton

--- a/app/screens/AddEmission/__tests__/__snapshots__/AddEmissionScreen.test.tsx.snap
+++ b/app/screens/AddEmission/__tests__/__snapshots__/AddEmissionScreen.test.tsx.snap
@@ -339,28 +339,17 @@ exports[`AddEmissionScreen renders correctly 1`] = `
           >
             Sunday 7th April 2019
           </Text.Primary>
+        </View>
+        <TouchableOpacity
+          onPress={[Function]}
+        >
           <Text.Primary
             bold={true}
-            lightGray={true}
+            green={true}
           >
-             - 
+            Change
           </Text.Primary>
-          <TouchableOpacity
-            onPress={[Function]}
-            style={
-              Object {
-                "paddingLeft": 4,
-              }
-            }
-          >
-            <Text.Primary
-              bold={true}
-              green={true}
-            >
-              Change
-            </Text.Primary>
-          </TouchableOpacity>
-        </View>
+        </TouchableOpacity>
       </View>
       <Button.Primary
         onPress={[Function]}


### PR DESCRIPTION
Addresses #214 

Moving it to the next line looks a little off to me. Any feedback on the screenshot below? I was thinking maybe if it was on the same line as the "Date" header?

Also I noticed that the date picker wasn’t rendering correctly and the modal that appears was blank. Is that happening for you as well or is it just my divide?

![BCEDC568-EEDA-4A56-90C3-C52980C6F144](https://user-images.githubusercontent.com/8363569/96328694-78a9a300-100b-11eb-9262-99095eb83160.png)
