### PR TITLE
Remove deprecated Linking from expo and minimised re-renders in AddEmissionScreen

### DIFF
--- a/app/components/SocialMedia/SocialMedia.tsx
+++ b/app/components/SocialMedia/SocialMedia.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { View, TouchableOpacity } from "react-native";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
-import { Linking } from "expo";
+import * as Linking from "expo-linking";
 
 import { Colors } from "../../style";
 

--- a/app/components/SocialMedia/__tests__/SocialMedia.test.tsx
+++ b/app/components/SocialMedia/__tests__/SocialMedia.test.tsx
@@ -1,13 +1,18 @@
 import React from "react";
 import { create } from "react-test-renderer";
-import { Linking } from "expo";
+import * as Linking from "expo-linking";
 
 import SocialMedia from "../";
 
 jest.unmock("../");
 
 beforeEach(() => {
-  Linking.openURL = jest.fn();
+  jest.spyOn(Linking, "openURL").mockImplementation((url: string) => {
+    if (url) {
+      return Promise.resolve(true);
+    }
+    Promise.reject(false);
+  });
 });
 
 test("renders correctly SocialMedia", () => {

--- a/app/interfaces/emission/emission.interface.ts
+++ b/app/interfaces/emission/emission.interface.ts
@@ -14,15 +14,17 @@ enum EmissionEnum {
   custom = "custom",
 }
 
+type EmissionModel =
+  | FoodEnum
+  | TransportEnum
+  | StreamingEnum
+  | ElectricityEnum
+  | "custom";
+
 interface EmissionPayload {
   name?: string;
   emissionType: EmissionEnum;
-  emissionModelType:
-    | FoodEnum
-    | TransportEnum
-    | StreamingEnum
-    | ElectricityEnum
-    | "custom";
+  emissionModelType: EmissionModel;
   value: number;
   creationDate: string;
   location?: ElectricityEnum;
@@ -33,4 +35,4 @@ interface Emission extends EmissionPayload {
   isMitigated: boolean;
 }
 
-export { Emission, EmissionPayload, EmissionEnum };
+export { Emission, EmissionPayload, EmissionEnum, EmissionModel };

--- a/app/screens/AddEmission/AddEmissionScreen.tsx
+++ b/app/screens/AddEmission/AddEmissionScreen.tsx
@@ -42,6 +42,7 @@ const DEFAULT_SLIDER_VALUE_TRANSPORT = 150 * 1000;
 const DEFAULT_SLIDER_VALUE_ELECTRICITY = 100 * 3.6 * Math.pow(10, 6);
 const DEFAULT_SLIDER_VALUE_STREAMING = 120 * 60;
 const DEFAULT_SLIDER_VALUE_CUSTOM = 200;
+const EMISSION_NAME_MAX_LENGTH = 150;
 
 const AddEmissionScreen = ({
   navigation,
@@ -197,7 +198,29 @@ const AddEmissionScreen = ({
     return null;
   };
 
+  const onTransportTagPress = useCallback(() => {
+    setEmissionType(EmissionEnum.transport);
+  }, []);
+  const onFoodTagPress = useCallback(() => {
+    setEmissionType(EmissionEnum.food);
+  }, []);
+  const onStreamingTagPress = useCallback(() => {
+    setEmissionType(EmissionEnum.streaming);
+  }, []);
+  const onElectricityTagPress = useCallback(() => {
+    setEmissionType(EmissionEnum.electricity);
+  }, []);
+  const onCustomTagPress = useCallback(() => {
+    setEmissionType(EmissionEnum.custom);
+  }, []);
+
   const isDarkModeEnabled = ui.isDarkModeEnabled();
+
+  const onChangeEmissionName = useCallback((name: string) => {
+    if (name.length < EMISSION_NAME_MAX_LENGTH) {
+      setEmissionName(name);
+    }
+  }, []);
 
   return (
     <KeyboardAwareScrollView style={styles.container}>
@@ -210,31 +233,31 @@ const AddEmissionScreen = ({
             icon={"md-airplane"}
             selected={emissionType === EmissionEnum.transport}
             title={t("ADD_EMISSION_TRANSPORT")}
-            onPress={() => setEmissionType(EmissionEnum.transport)}
+            onPress={onTransportTagPress}
           />
           <Tag
             icon={"md-restaurant"}
             selected={emissionType === EmissionEnum.food}
             title={t("ADD_EMISSION_FOOD")}
-            onPress={() => setEmissionType(EmissionEnum.food)}
+            onPress={onFoodTagPress}
           />
           <Tag
             icon={"md-play-circle"}
             selected={emissionType === EmissionEnum.streaming}
             title={t("ADD_EMISSION_STREAMING")}
-            onPress={() => setEmissionType(EmissionEnum.streaming)}
+            onPress={onStreamingTagPress}
           />
           <Tag
             icon={"md-flash"}
             selected={emissionType === EmissionEnum.electricity}
             title={t("ADD_EMISSION_ELECTRICITY")}
-            onPress={() => setEmissionType(EmissionEnum.electricity)}
+            onPress={onElectricityTagPress}
           />
           <Tag
             icon={"md-build"}
             selected={emissionType === EmissionEnum.custom}
             title={t("ADD_EMISSION_CUSTOM")}
-            onPress={() => setEmissionType(EmissionEnum.custom)}
+            onPress={onCustomTagPress}
           />
           <View style={styles.separator} />
         </ScrollView>
@@ -250,11 +273,7 @@ const AddEmissionScreen = ({
         isOptional
         placeholder={t("ADD_EMISSION_TEXTINPUT_PLACEHOLDER")}
         title={t("ADD_EMISSION_NAME_EMISSION")}
-        onChangeText={(name) => {
-          if (name.length < 150) {
-            setEmissionName(name);
-          }
-        }}
+        onChangeText={onChangeEmissionName}
         value={emissionName}
       />
 

--- a/app/screens/Settings/components/SettingsRow/__tests__/SettingsRow.test.tsx
+++ b/app/screens/Settings/components/SettingsRow/__tests__/SettingsRow.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Linking } from "expo";
+import * as Linking from "expo-linking";
 import { create } from "react-test-renderer";
 
 import SettingsRow from "../SettingsRow";
@@ -7,7 +7,12 @@ import SettingsRow from "../SettingsRow";
 jest.unmock("../SettingsRow");
 
 beforeEach(() => {
-  Linking.openURL = jest.fn();
+  jest.spyOn(Linking, "openURL").mockImplementation((url: string) => {
+    if (url) {
+      return Promise.resolve(true);
+    }
+    Promise.reject(false);
+  });
 });
 
 const props = {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "expo-asset": "8.2.0",
     "expo-constants": "9.2.0",
     "expo-font": "8.3.0",
+    "expo-linking": "^1.0.4",
     "expo-localization": "9.0.0",
     "expo-splash-screen": "0.6.1",
     "expo-status-bar": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "expo-asset": "8.2.0",
     "expo-constants": "9.2.0",
     "expo-font": "8.3.0",
-    "expo-linking": "^1.0.4",
+    "expo-linking": "1.0.4",
     "expo-localization": "9.0.0",
     "expo-splash-screen": "0.6.1",
     "expo-status-bar": "1.0.2",
@@ -109,7 +109,7 @@
     "jest-expo": "39.0.0",
     "markdown-it": "10.0.0",
     "prettier": "2.1.2",
-    "prompt-sync": "^4.2.0",
+    "prompt-sync": "4.2.0",
     "react-native-storybook-loader": "1.8.1",
     "typescript": "3.9.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6535,7 +6535,7 @@ expo-linear-gradient@~8.3.0:
   resolved "https://registry.yarnpkg.com/expo-linear-gradient/-/expo-linear-gradient-8.3.1.tgz#5dd3878c0700035d55241a4a453c5e224acc60ff"
   integrity sha512-zlWGua8vm7+af4otaSpJlzu0SYIr0aWbL0qICySCDUEKkqig6MqfuI69NYHC0w9ocWZuh2xyj6Rbfy01UqcVSg==
 
-expo-linking@~1.0.4:
+expo-linking@^1.0.4, expo-linking@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/expo-linking/-/expo-linking-1.0.4.tgz#ca8bdff42e0bb3cd29c387bf236218eb2ffb27cc"
   integrity sha512-tKZvn3D2t/rJQQbDXZaPl3pEZvyO2coSO1WHtXeOCUaWFjrrHxjW0HAZ2H2iR0zALPq/lXo0Po83RsES3E0DAg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6535,7 +6535,7 @@ expo-linear-gradient@~8.3.0:
   resolved "https://registry.yarnpkg.com/expo-linear-gradient/-/expo-linear-gradient-8.3.1.tgz#5dd3878c0700035d55241a4a453c5e224acc60ff"
   integrity sha512-zlWGua8vm7+af4otaSpJlzu0SYIr0aWbL0qICySCDUEKkqig6MqfuI69NYHC0w9ocWZuh2xyj6Rbfy01UqcVSg==
 
-expo-linking@^1.0.4, expo-linking@~1.0.4:
+expo-linking@1.0.4, expo-linking@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/expo-linking/-/expo-linking-1.0.4.tgz#ca8bdff42e0bb3cd29c387bf236218eb2ffb27cc"
   integrity sha512-tKZvn3D2t/rJQQbDXZaPl3pEZvyO2coSO1WHtXeOCUaWFjrrHxjW0HAZ2H2iR0zALPq/lXo0Po83RsES3E0DAg==
@@ -11221,7 +11221,7 @@ promise@^8.0.3:
   dependencies:
     asap "~2.0.6"
 
-prompt-sync@^4.2.0:
+prompt-sync@4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/prompt-sync/-/prompt-sync-4.2.0.tgz#0198f73c5b70e3b03e4b9033a50540a7c9a1d7f4"
   integrity sha512-BuEzzc5zptP5LsgV5MZETjDaKSWfchl5U9Luiu8SKp7iZWD5tZalOxvNcZRwv+d2phNFr8xlbxmFNcRKfJOzJw==


### PR DESCRIPTION
Following changes are made.

- Updated usage of `Linking` from `expo` since it is deprecated, as per the following screenshot 
   ![image](https://user-images.githubusercontent.com/29015897/96346650-96821100-10ba-11eb-94fe-18dc051d67fe.png)
- Moved a few callbacks to `useCallback` to minimise the re-renders.
- Added some constants for readability

