### PR TITLE
Fixed the unexpected line break in the imports group

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,7 +57,7 @@ module.exports = {
               "internal",
               ["parent", "sibling", "index"],
             ],
-            "newlines-between": "always-and-inside-groups",
+            "newlines-between": "always",
           },
         ],
     }

--- a/app/components/SocialMedia/SocialMedia.tsx
+++ b/app/components/SocialMedia/SocialMedia.tsx
@@ -4,7 +4,6 @@ import { MaterialCommunityIcons } from "@expo/vector-icons";
 import * as Linking from "expo-linking";
 
 import { Colors } from "../../style";
-
 import styles from "./SocialMedia.styles";
 
 const socialMedia = [

--- a/app/components/Text/stories/Text.story.tsx
+++ b/app/components/Text/stories/Text.story.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-
 import { storiesOf } from "@storybook/react-native";
 import { text } from "@storybook/addon-knobs";
 

--- a/app/navigation/Navigator/BottomTab/ActTabNavigator.tsx
+++ b/app/navigation/Navigator/BottomTab/ActTabNavigator.tsx
@@ -5,7 +5,6 @@ import { GuideCategory } from "../../../types/guide";
 import { Text } from "../../../components";
 import { t } from "../../../utils";
 import { ComponentsStyle, Colors, Font } from "../../../style";
-
 import ActScreen from "../../../screens/Act";
 
 const Tab = createMaterialTopTabNavigator();

--- a/app/navigation/Navigator/BottomTabNavigator.tsx
+++ b/app/navigation/Navigator/BottomTabNavigator.tsx
@@ -3,10 +3,8 @@ import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { Colors } from "../../style";
-
 import TabBarIcon from "../../components/TabBarIcon";
 import { t } from "../../utils";
-
 import ActNavigator from "./BottomTab/ActNavigator";
 import BudgetNavigator from "./BottomTab/BudgetNavigator";
 import EmissionsNavigator from "./BottomTab/EmissionsNavigator";

--- a/app/screens/About/AboutScreen.tsx
+++ b/app/screens/About/AboutScreen.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { ScrollView, View } from "react-native";
 
 import { Text, StickersImage } from "components";
-
 import { t } from "utils";
 
 import styles from "./AboutScreen.styles";

--- a/app/screens/ActDetail/ActDetailScreen.tsx
+++ b/app/screens/ActDetail/ActDetailScreen.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 import { Dimensions, ScrollView } from "react-native";
-
 import HTML from "react-native-render-html";
 
 import { ui } from "../../utils";
-
 import { HTMLImage } from "../../components";
 import styles from "./ActDetailScreen.styles";
 import navigationOptions from "./ActDetailScreen.navigationOptions";

--- a/app/screens/AddEmission/__tests__/AddEmissionScreen.test.tsx
+++ b/app/screens/AddEmission/__tests__/AddEmissionScreen.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { create } from "react-test-renderer";
-
 import { FormattedProvider } from "react-native-globalize";
 
 import AddEmissionScreen from "../AddEmissionScreen";

--- a/app/screens/AddEmission/components/Transport/Transport.tsx
+++ b/app/screens/AddEmission/components/Transport/Transport.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { View, ScrollView } from "react-native";
 import Slider from "@react-native-community/slider";
 import { FormattedNumber } from "react-native-globalize";
-
 import { transport, TransportEnum } from "carbon-footprint";
 
 import styles from "./Transport.styles";

--- a/app/screens/Budget/components/NumberOfDaysVegetarian/ducks/__tests__/NumberOfDaysVegetarian.selectors.test.ts
+++ b/app/screens/Budget/components/NumberOfDaysVegetarian/ducks/__tests__/NumberOfDaysVegetarian.selectors.test.ts
@@ -1,5 +1,4 @@
 import { FoodEnum } from "carbon-footprint";
-
 import moment from "moment";
 
 import { selectors } from "../";

--- a/app/screens/Budget/ducks/__tests__/BudgetScreen.selectors.test.ts
+++ b/app/screens/Budget/ducks/__tests__/BudgetScreen.selectors.test.ts
@@ -1,11 +1,9 @@
 import { FoodEnum, TransportEnum } from "carbon-footprint";
-
 import moment from "moment";
 
 import { selectors } from "../";
 import emissions from "../../../../ducks/emissions";
 import { Emission, EmissionType } from "../../../../interfaces";
-
 import { calculation } from "../../../../utils";
 
 let state;

--- a/app/screens/Emissions/EmissionsScreen.tsx
+++ b/app/screens/Emissions/EmissionsScreen.tsx
@@ -8,7 +8,6 @@ import { Text, Button } from "components";
 import { t } from "../../utils";
 import { budget } from "../../ducks";
 import { navigate } from "../../navigation";
-
 import styles from "./EmissionsScreen.styles";
 import { EmissionsList } from "./components";
 import { selectors } from "./ducks";

--- a/app/screens/Emissions/components/EmissionsList/__tests__/EmissionsList.test.tsx
+++ b/app/screens/Emissions/components/EmissionsList/__tests__/EmissionsList.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { create } from "react-test-renderer";
-
 import { FoodEnum, TransportEnum } from "carbon-footprint";
 
 import EmissionsList from "../EmissionsList";

--- a/app/screens/Emissions/components/EmissionsListItem/__tests__/EmissionListItem.test.tsx
+++ b/app/screens/Emissions/components/EmissionsListItem/__tests__/EmissionListItem.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { create } from "react-test-renderer";
-
 import { FormattedProvider } from "react-native-globalize";
 import { FoodEnum, TransportEnum, StreamingEnum } from "carbon-footprint";
 

--- a/app/screens/Emissions/components/EmissionsListItem/stories/EmissionsListItem.story.tsx
+++ b/app/screens/Emissions/components/EmissionsListItem/stories/EmissionsListItem.story.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-
 import { storiesOf } from "@storybook/react-native";
 import { text, boolean, number, select } from "@storybook/addon-knobs";
 

--- a/app/screens/Emissions/ducks/__tests__/EmissionsScreen.selectors.test.ts
+++ b/app/screens/Emissions/ducks/__tests__/EmissionsScreen.selectors.test.ts
@@ -1,5 +1,4 @@
 import { FoodEnum, TransportEnum } from "carbon-footprint";
-
 import moment from "moment";
 
 import { selectors } from "../";

--- a/app/screens/Settings/SettingsScreen.tsx
+++ b/app/screens/Settings/SettingsScreen.tsx
@@ -7,7 +7,6 @@ import {
   Platform,
 } from "react-native";
 import ExpoConstants from "expo-constants";
-
 import * as WebBrowser from "expo-web-browser";
 
 import { ImagesAssets } from "constant";

--- a/app/utils/translations/resources.ts
+++ b/app/utils/translations/resources.ts
@@ -1,3 +1,4 @@
+/* eslint import/order:0 */
 /* SCREENS */
 import * as Act from "../../screens/Act/translations";
 import * as Budget from "../../screens/Budget/translations";

--- a/app/utils/ui/__tests__/ui.test.ts
+++ b/app/utils/ui/__tests__/ui.test.ts
@@ -12,7 +12,6 @@ import {
 } from "react-native";
 
 import { EmissionType } from "../../../interfaces";
-
 import ui from "../";
 import * as translationUtils from "../../translations/i18n";
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate a lot your help. Please provide some information so that others can review your pull request. The two last fields below are optional but appreciated. -->

✅ I have read the [contributing file](https://github.com/NMF-earth/nmf-app/blob/master/contributing.md)

## Summary

Fixes #172
issue where auto save -> Reformat add extra new line in the imports
 

<!-- MANDATORY : Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

Updated `newlines-between` to `always` as per https://dev.to/otamnitram/sorting-your-imports-correctly-in-react-213m
<!-- Help reviewers and the release process by writing your own changelog entry -->

## Demo

On top of BudgetScreen.tsx, we have :

```
import React from "react";
import { ScrollView } from "react-native";
import { useSelector } from "react-redux";

import styles from "./BudgetScreen.styles";
import { Text, Button } from "../../components";

```

If changed it to the following :

```
import React from "react";
import { ScrollView } from "react-native";

import styles from "./BudgetScreen.styles";
import { useSelector } from "react-redux";
import { Text, Button } from "../../components";
```

And save the file, get the following :

```
import React from "react";
import { ScrollView } from "react-native";
import { useSelector } from "react-redux";

import styles from "./BudgetScreen.styles";
import { Text, Button } from "../../components";

```

Instead of :
```
import React from "react";
import { ScrollView } from "react-native";

import { useSelector } from "react-redux";

import styles from "./BudgetScreen.styles";
import { Text, Button } from "../../components";

```


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
