### PR TITLE
(#339) Present PermissionsRequest in Notification screen

### DIFF
--- a/app/components/PermissionsRequest/__tests__/__snapshots__/PermissionsRequest.test.tsx.snap
+++ b/app/components/PermissionsRequest/__tests__/__snapshots__/PermissionsRequest.test.tsx.snap
@@ -85,12 +85,12 @@ exports[`renders correctly PermissionsRequest if notification 1`] = `
     <Text.H2
       center={true}
     >
-      
+      No permission to send notifications
     </Text.H2>
     <Text.Primary
       center={true}
     >
-      
+      Please give NMF.earth app permission to send you notifications in your phone settings to use this feature.
     </Text.Primary>
   </View>
   <Button.Secondary

--- a/app/components/PermissionsRequest/translations/en.json
+++ b/app/components/PermissionsRequest/translations/en.json
@@ -2,6 +2,6 @@
   "PERMISSIONS_REQUEST_COMPONENT_OPEN_SETTINGS": "Open settings",
   "PERMISSIONS_REQUEST_COMPONENT_CAMERA_TITLE": "No access to camera",
   "PERMISSIONS_REQUEST_COMPONENT_CAMERA_SUBTITLE": "Please give NMF.earth app access to camera in your phone settings to use this feature.",
-  "PERMISSIONS_REQUEST_COMPONENT_NOTIFICATION_TITLE": "",
-  "PERMISSIONS_REQUEST_COMPONENT_NOTIFICATION_SUBTITLE": ""
+  "PERMISSIONS_REQUEST_COMPONENT_NOTIFICATION_TITLE": "No permission to send notifications",
+  "PERMISSIONS_REQUEST_COMPONENT_NOTIFICATION_SUBTITLE": "Please give NMF.earth app permission to send you notifications in your phone settings to use this feature."
 }

--- a/app/screens/Notifications/__tests__/__snapshots__/NotificationsScreen.tests.tsx.snap
+++ b/app/screens/Notifications/__tests__/__snapshots__/NotificationsScreen.tests.tsx.snap
@@ -9,44 +9,5 @@ exports[`NotificationsScreen renders correctly 1`] = `
       "paddingHorizontal": 16,
     }
   }
->
-  <Text.Primary
-    style={
-      Object {
-        "paddingTop": 30,
-      }
-    }
-  >
-    Receive a notification every Sunday at 9 p.m to remind you to add your weekly emissions.
-  </Text.Primary>
-  <View
-    style={
-      Object {
-        "alignItems": "center",
-        "flexDirection": "row",
-        "justifyContent": "space-between",
-        "marginTop": 22,
-      }
-    }
-  >
-    <Text.Secondary
-      bold={true}
-    >
-      Activated
-    </Text.Secondary>
-    <RCTSwitch
-      accessibilityRole="switch"
-      onChange={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        Object {
-          "height": 31,
-          "width": 51,
-        }
-      }
-      value={false}
-    />
-  </View>
-</View>
+/>
 `;

--- a/scripts/poeditor/en.json
+++ b/scripts/poeditor/en.json
@@ -217,6 +217,6 @@
 	"PERMISSIONS_REQUEST_COMPONENT_OPEN_SETTINGS": "Open settings",
 	"PERMISSIONS_REQUEST_COMPONENT_CAMERA_TITLE": "No access to camera",
 	"PERMISSIONS_REQUEST_COMPONENT_CAMERA_SUBTITLE": "Please give NMF.earth app access to camera in your phone settings to use this feature.",
-	"PERMISSIONS_REQUEST_COMPONENT_NOTIFICATION_TITLE": "",
-	"PERMISSIONS_REQUEST_COMPONENT_NOTIFICATION_SUBTITLE": ""
+	"PERMISSIONS_REQUEST_COMPONENT_NOTIFICATION_TITLE": "No permission to send notifications",
+	"PERMISSIONS_REQUEST_COMPONENT_NOTIFICATION_SUBTITLE": "Please give NMF.earth app permission to send you notifications in your phone settings to use this feature."
 }


### PR DESCRIPTION
✅ I have read the [contributing file](https://github.com/NMF-earth/nmf-app/blob/main/contributing.md)

## Summary

Closes #339 

## Changelog

- Update snapshots
- Check for permissions on useEffect in Notifications screen
- Use PermissionsRequest component to require permissions in Notifications screen
- Add necessary translations

## Demo

![image](https://user-images.githubusercontent.com/39802870/139155519-63c26c98-460a-4fe9-bd67-dcb9e04e3330.png)

