### PR TITLE
Set the selected language to i18n.locale so the app language changes.

### DIFF
--- a/app/screens/Languages/LanguagesScreen.tsx
+++ b/app/screens/Languages/LanguagesScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useContext } from "react";
 import { View, ScrollView } from "react-native";
 import { useDispatch } from "react-redux";
+import i18n from "i18n-js";
 
 import { SelectableListItem } from "components";
 import { userPreferences } from "ducks";
@@ -36,6 +37,7 @@ const LanguagesScreen: NavStatelessComponent = () => {
     (lang: string) => {
       dispatch(userPreferences.actions.changeLanguage(lang));
       setLanguage(lang);
+      i18n.locale = lang;
     },
     [dispatch, setLanguage]
   );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate a lot your help. Please provide some information so that others can review your pull request. The two last fields below are optional but appreciated. -->

✅ I have read the [contributing file](https://github.com/NMF-earth/nmf-app/blob/main/contributing.md)

## Summary

This PR Fixes #249
By Enabling app to show string based on user-selected language

## Changelog

Add call to set `i18n.locale` when user change language from language screen

## Demo

![RPReplay_Final1635614236](https://user-images.githubusercontent.com/13498448/139542802-e2c8232f-8cb1-4bb1-acda-87d3882dd25b.gif)

