### PR TITLE
Resolved incorrect locale casing for period on 'Carbon Budget' view

### DIFF
--- a/app/screens/Budget/components/ProgressChart/ProgressChart.tsx
+++ b/app/screens/Budget/components/ProgressChart/ProgressChart.tsx
@@ -71,7 +71,7 @@ const ProgressChart = ({
         productScannedEmissions={productScannedEmissions}
         customEmissions={customEmissions}
       />
-      <PeriodBudget period={period.toLowerCase()} periodEmissionsBudget={periodEmissionsBudget} />
+      <PeriodBudget period={period} periodEmissionsBudget={periodEmissionsBudget} />
     </View>
   );
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate a lot your help. Please provide some information so that others can review your pull request. The two last fields below are optional but appreciated. -->

✅ I have read the [contributing file](https://github.com/NMF-earth/nmf-app/blob/main/contributing.md)

## Summary
This aims to display the correct period information in the Carbon Budget view by removing a function call that makes the period lowercase on the PeriodBudget component. As shown below, the locale casing for the period on the ProgressChart component is incorrect. 

The lack of capitalization of the month of "November" caught my attention as I was familiarizing myself with the platform. I figured this was a great starting point for my first contribution to the nmf-app project!

## Changelog
Removed a call to `toLowerCase()` on when passing the `period` prop to the `PeriodBudget` component within the ProgressChart view. 

<!-- Help reviewers and the release process by writing your own changelog entry -->

## Demo
Progress Chart Before
<img width="334" alt="Period Budget Before" src="https://user-images.githubusercontent.com/25915763/141605411-785fdac6-1967-495e-b883-2897db4998bb.png">
Progress Chart After
<img width="333" alt="Period Budget After" src="https://user-images.githubusercontent.com/25915763/141605415-f3ec5f03-79b8-45f1-9bfe-dcf9187fc358.png">


