### PR TITLE
[#379] Fixing the bug where scanned products will show 200 as CO2e

### DIFF
--- a/app/screens/AddEmission/AddEmissionScreen.tsx
+++ b/app/screens/AddEmission/AddEmissionScreen.tsx
@@ -53,6 +53,7 @@ const DEFAULT_SLIDER_VALUE_PURCHASE = 1;
 const DEFAULT_SLIDER_VALUE_FASHION = 1;
 const DEFAULT_SLIDER_VALUE_MEAL = 1;
 const DEFAULT_SLIDER_VALUE_CUSTOM = 200;
+const DEFAULT_SLIDER_VALUE_SCANNED = 1;
 const EMISSION_NAME_MAX_LENGTH = 150;
 
 const getProductCarbonFootprint = pathOr(0, ["params", "productCarbonFootprint"]);
@@ -78,6 +79,7 @@ const AddEmissionScreen = ({ locale = "", language = "" }: LocalizationContextPr
   );
   const [durationSeconds, setDurationSeconds] = useState<number>(DEFAULT_SLIDER_VALUE_STREAMING);
   const [co2eqKilograms, setCo2eqKilograms] = useState<number>(DEFAULT_SLIDER_VALUE_CUSTOM);
+  const [productScannedQuantity, setProductScannedQuantity] = useState<number>(DEFAULT_SLIDER_VALUE_SCANNED);
   const [distance, setDistance] = useState<number>(DEFAULT_SLIDER_VALUE_TRANSPORT);
   const [foodQuantity, setFoodQuantity] = useState<number>(DEFAULT_SLIDER_VALUE_FOOD);
   const [purchaseQuantity, setPurchaseQuantity] = useState<number>(DEFAULT_SLIDER_VALUE_PURCHASE);
@@ -267,13 +269,14 @@ const AddEmissionScreen = ({ locale = "", language = "" }: LocalizationContextPr
 
   const renderProductScanned = () => {
     if (emissionType === EmissionType.productScanned) {
-      emissionPayload.value = co2eqKilograms;
+      emissionPayload.value = productScannedQuantity * productCarbonFootprint;
       emissionPayload.emissionModelType = EmissionType.productScanned as EmissionModelType;
 
       return (
         <ProductScanned
           productCarbonFootprint={productCarbonFootprint}
-          setCo2eqKilograms={setCo2eqKilograms}
+          defaultValueSlider={DEFAULT_SLIDER_VALUE_SCANNED}
+          setProductScannedQuantity={setProductScannedQuantity}
         />
       );
     }

--- a/app/screens/AddEmission/components/ProductScanned/ProductScanned.tsx
+++ b/app/screens/AddEmission/components/ProductScanned/ProductScanned.tsx
@@ -16,20 +16,18 @@ const MAX_SLIDER_VALUE = 10;
 
 interface Props {
   productCarbonFootprint: number;
-  setCo2eqKilograms: (arg0: number) => void;
+  defaultValueSlider:number;
+  setProductScannedQuantity: (arg0: number) => void;
 }
 
-const ProductScanned: React.FC<Props> = ({ setCo2eqKilograms, productCarbonFootprint }) => {
-  const [sliderValue, setSliderValue] = useState(1.4);
+const ProductScanned: React.FC<Props> = ({ setProductScannedQuantity, defaultValueSlider, productCarbonFootprint }) => {
+  const [sliderValue, setSliderValue] = useState(defaultValueSlider);
 
-  const emissionAmount =
-    productCarbonFootprint < 1
-      ? Math.round(Math.round(sliderValue) * productCarbonFootprint * 1000) / 1000
-      : Math.round(Math.round(sliderValue) * productCarbonFootprint * 10) / 10;
-
+  const emissionAmount = Math.round(sliderValue) * productCarbonFootprint
+  
   const onSliderValueChange = (value: number) => {
     setSliderValue(value);
-    setCo2eqKilograms(emissionAmount);
+    setProductScannedQuantity(Math.round(value));
   };
 
   const useMetricUnits = useSelector(userPreferences.selectors.getUseMetricUnits);


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate a lot your help. Please provide some information so that others can review your pull request. The two last fields below are optional but appreciated. -->

✅ I have read the [contributing file](https://github.com/NMF-earth/nmf-app/blob/main/contributing.md)

## Summary

<!-- MANDATORY : Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
https://github.com/NMF-earth/nmf-app/issues/379

This bug happened if the slider was not moved before adding the scanned product to the emission lists. This happened because in the default value that was passed to the packageScanScreen the emission value that is read from Open Food database was not taken in consideration


## Changelog
* Made changes to ProductScanned.tsx to set product scanned quantity instead of the total emission value
* Made changes to AddEmissionScreen to set the emission value after multiplying the quantity with the productCarbonFootprint that is fetched from the Open Food database

<!-- Help reviewers and the release process by writing your own changelog entry -->

## Demo

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
* Tested the App by scanning a product and not moving the slider and adding it to the emission list
* Tested the App by scanning a product and changing the quantity 
* Tested the App by adding a custom product
