### PR TITLE
Fixed Polish translation Issue #390

### DIFF
--- a/app/screens/Languages/__tests__/__snapshots__/LanguagesScreen.tests.tsx.snap
+++ b/app/screens/Languages/__tests__/__snapshots__/LanguagesScreen.tests.tsx.snap
@@ -173,7 +173,7 @@ exports[`LanguageScreen renders correctly 1`] = `
             }
           }
         >
-          Polskie
+          Polski
         </Text.Primary>
       </TouchableOpacity>
       <TouchableOpacity

--- a/app/utils/translations/languages.tsx
+++ b/app/utils/translations/languages.tsx
@@ -9,7 +9,7 @@ const supportedLanguages = {
   sv: "Svenska",
   ru: "Pусский",
   pt: "Português",
-  pl: "Polskie",
+  pl: "Polski",
   da: "Dansk",
   zh: "中文（简体）",
   ms: "Bahasa Melayu",


### PR DESCRIPTION
Fixed issue in Languages when it stated "Polskie" it is wrong and should show "Polski"

I run all tests and all tests passed



✅ I have read the [contributing file](https://github.com/NMF-earth/nmf-app/blob/main/contributing.md)

## Summary

Fix Translation in Polish "Polskie" to "Polski"

## Changelog

Changed "Polskie" to "Polski"
app/utils/translations/languages.tsx
app/screens/Languages/__tests__/__snapshots__/LanguagesScreen.tests.tsx.snap

## Demo
![Zrzut ekranu 2024-04-16 o 15 47 50](https://github.com/NMF-earth/nmf-app/assets/123777101/ed2ce472-5f0a-46ab-be31-1886c7190668)


![Zrzut ekranu 2024-04-16 o 15 46 13](https://github.com/NMF-earth/nmf-app/assets/123777101/e74d3579-5425-4e43-b0f9-c73a1921b4b1)


