### PR TITLE
Reduce CI runs by ignoring pushes to branch and non-functional files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,15 @@
 name: Run CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ "main" ]
+    paths-ignore:
+      - '**.md'
+      - '.vscode/*'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '.vscode/*'
 
 jobs:
   build:


### PR DESCRIPTION
✅ I have read the [contributing file](https://github.com/NMF-earth/nmf-app/blob/main/contributing.md)

## Summary

While submitting a PR for Eco-CI (https://github.com/NMF-earth/nmf-app/pull/393) I noticed that the pipeline was triggering two times everytime I push to the branch of the PR.

To my understanding this was because the *on-trigger* was set to push and pull_request without limiting it to a specific branch.

I this submit a PR that will trigger on-push runs only on the main branch. 
This change however follows the idea that every addition to the code is either pushed directly to main or always coming through a feature-branch that will be merged in through a pull-request.

For pushes to pull-requests the trigger will still run, meaning that all pushes to a PR will trigger a new CI run.

Furthermore I added some exclusions that will not trigger runs like for instance markdown files and the `.vscode` directory. 

Feel free to add more directories that are deemed non-functional.

The intention of this PR is to reduce CI runs and this save a bit of energy, Github minutes and potentially CO2.

Hope you like the addition!
## Changelog

- Exclusions added to github workflow when to not run. Markdown files and .vscode directory
- PR runs on push now only on main branch and on pull_request (any branch.)

