### PR TITLE
refactor: move FaqScreen ScrollView padding to contentContainerStyle

### DIFF
--- a/app/screens/Faq/FaqScreen.styles.ts
+++ b/app/screens/Faq/FaqScreen.styles.ts
@@ -5,6 +5,8 @@ import { Colors } from "style";
 const styles = StyleSheet.create({
   container: {
     backgroundColor: Colors.white,
+  },
+  contentContainer: {
     paddingHorizontal: 16,
     paddingVertical: 24,
   },

--- a/app/screens/Faq/FaqScreen.tsx
+++ b/app/screens/Faq/FaqScreen.tsx
@@ -10,7 +10,10 @@ import navigationOptions from "./FaqScreen.navigationOptions";
 
 const FaqScreen: NavStatelessComponent = () => {
   return (
-    <ScrollView style={styles.container}>
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.contentContainer}
+    >
       <Accordion>
         {content.map((content, index) => (
           <Accordion.Item key={index} title={content.title}>

--- a/app/screens/Faq/__tests__/__snapshots__/FaqScreen.test.tsx.snap
+++ b/app/screens/Faq/__tests__/__snapshots__/FaqScreen.test.tsx.snap
@@ -2,11 +2,15 @@
 
 exports[`FaqScreen renders correctly 1`] = `
 <RCTScrollView
+  contentContainerStyle={
+    {
+      "paddingHorizontal": 16,
+      "paddingVertical": 24,
+    }
+  }
   style={
     {
       "backgroundColor": "#FFFFFF",
-      "paddingHorizontal": 16,
-      "paddingVertical": 24,
     }
   }
 >


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate a lot your help. Please provide some information so that others can review your pull request. The two last fields below are optional but appreciated. -->

✅ I have read the [contributing file](https://github.com/NMF-earth/nmf-app/blob/main/contributing.md)

## Summary

Fixes #399 

## Changelog

- Move FaqScreen ScrollView padding to contentContainerStyle

## Demo

| Android  | iOS |
|:--------|:-----------:|
| <img width="1080" height="2400" alt="Image" src="https://github.com/user-attachments/assets/a857c1a2-b291-4a29-bb9d-7f0ff8f8743a" /> | <img width="1170" height="2532" alt="Image" src="https://github.com/user-attachments/assets/d88612b5-f641-4f3d-a196-7bc5fd233b63" /> |


